### PR TITLE
Updated the Enums section to use proper terminology.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ var currentState = State.Open
 var previousState = States.Closed // Reads less clearly than the previous option.
 ```
 
-For enums with associated values, declare the associated value on the same line as its declaration:
+For enums with raw values, declare the raw value on the same line as its declaration:
 
 ```swift
 internal enum HTTPMethod: String {


### PR DESCRIPTION
I'm being pedantic here. But, the third example in the Enums section shows definition of an Enum with _raw values_, not _associated values_. Here is the [section about Enums](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Enumerations.html) on the official Swift documentations.
