### PR TITLE
Updated file structure section to have something more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,12 @@ guide your design principals.
 
 ### File structure ###
 
-You should not define multiple public/internal types (ie class, struct, enum) in the same file; each type should have its own file. If an enum or protocol is related to the class but has to be known outside define it inside the class file.
-
-E.g., The following enum can be used for both networking and data storage, so it should live as it's own entity:
-
-```swift
-enum Result<T> {
-    case Success(T)
-    case Failure(String)
-}
-```
+You should not define multiple public/internal types (ie class, struct, enum) in the same file; each type should have its own file.
 
 The following list should be the standard organization of all your Swift files, in this specific order:
 
 Before the type declaration:
 
-* Enum (if only related to the file's class)
-* Protocol (if only related to the file's class)
 * Private Class/Struct/Enum
 
 Inside the type declaration:

--- a/README.md
+++ b/README.md
@@ -50,12 +50,23 @@ guide your design principals.
 
 ### File structure ###
 
-You should not define multiple public/internal types (ie class, struct, enum) in the same file; each type should have its own file.
+You should not define multiple public/internal types (ie class, struct, enum) in the same file; each type should have its own file. If an enum or protocol is related to the class but has to be known outside define it inside the class file.
+
+E.g., The following enum can be used for both networking and data storage, so it should live as it's own entity:
+
+```swift
+enum Result<T> {
+    case Success(T)
+    case Failure(String)
+}
+```
 
 The following list should be the standard organization of all your Swift files, in this specific order:
 
 Before the type declaration:
 
+* Enum (if only related to the file's class)
+* Protocol (if only related to the file's class)
 * Private Class/Struct/Enum
 
 Inside the type declaration:
@@ -86,33 +97,7 @@ All enums should live in their own code file, except in cases where the enum is 
 
 #### Usage of MARK ####
 
-To help organizing your files you may want to use pragma marks to clearly separate your functions, properties and extensions. Only use them for the groups defined above. For extensions, use one MARK per extension. For example, `// MARK: UITableViewDelegate` instead of `// MARK: Extensions`
-
-```swift
-// MARK: Functions
-
-override func viewDidLoad() {
-}
-
-public func doSomething() {
-}
-
-internal func doSomething() {
-}
-
-private func doSomethingElse() {
-}
-
-// MARK: UITableViewDelegate Extension
-
-extension UIViewController: UITableViewDelegate {
-}
-
-// MARK: UITableViewDataSource Extension
-
-extension UIViewController: UITableViewDataSource {
-}
-```
+To help organizing your files you may want to use pragma marks to clearly separate your functions, properties and extensions. For extensions, use one MARK per extension. For example, `// MARK: UITableViewDelegate` instead of `// MARK: Extensions`.
 
 ### Statement Termination ###
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ across the board and makes our lives as developers considerably easier.
 ### Force Unwrap ###
 
 Unless there is a situation that absolutely calls for it, usage of the force-unwrap operator `(!)` should
-be minmized, if not eliminated all together. With the many and varied ways of unwrapping optionals, it is
+be minimized, if not eliminated all together. With the many and varied ways of unwrapping optionals, it is
 safer and simpler to declare variables as optional and unwrap them when needing their values than it is
 to force-unwrap them and potentially introduce runtime errors into the code base.
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ Each section above should be organized by accessibility:
 
 When implementing a protocol you should create an extension of your class that lives in the same file to separate the core logic of your class and your protocol implementation.
 
-#### Enum ####
+#### Enum & Protocol ####
 
-All enums should live in their own code file, except in cases where the enum is declared as private. In cases where the enum is declared private, declare the enum at the top of the code file, above the type declaration.
+All enums should live in their own file, except in cases where the enum is declared as private. In cases where the enum is declared private, declare the enum at the top of the file, above the type declaration.
 
-*Rationale*: With enums and protocols types Swift allows defining functions and extensions. Because of that these types can become complex which is why they should be defined in their own file.
+*Rationale*: With enum and protocol types Swift allows defining functions and extensions. Because of that these types can become complex which is why they should be defined in their own file.
 
 #### Usage of MARK / TODO / FIXME ####
 
@@ -96,7 +96,7 @@ Xcode is also able to display `TODO` and `FIXME` tags directly in the source nav
 
 `// FIXME: fix it it's not working`
 
-Other conventional comment tags, such as `NOTE` and `XXX` are not recognized by Xcode.
+Other conventional comment tags, such as `NOTE` are not recognized by Xcode.
 
 ### Statement Termination ###
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Table Of Contents ##
 
 * [Overview](#overview)
-* **Standards**
+* [Standards](#standards)
 	* [File Structure](#file-structure)
 	* [Statement Termintaion](#statement-termination)
 	* [Variable Declaration](#variable-declaration)

--- a/README.md
+++ b/README.md
@@ -84,9 +84,19 @@ When implementing a protocol you should create an extension of your class that l
 
 All enums should live in their own code file, except in cases where the enum is declared as private. In cases where the enum is declared private, declare the enum at the top of the code file, above the type declaration.
 
-#### Usage of MARK ####
+*Rationale*: With enums and protocols types Swift allows defining functions and extensions. Because of that these types can become complex which is why they should be defined in their own file.
 
-To help organizing your files you may want to use pragma marks to clearly separate your functions, properties and extensions. For extensions, use one MARK per extension. For example, `// MARK: UITableViewDelegate` instead of `// MARK: Extensions`.
+#### Usage of MARK / TODO / FIXME ####
+
+To help organizing your files you may want to use pragma marks to clearly separate your functions, properties and extensions. For extensions, use one MARK per extension. For example, `// MARK: UITableViewDelegate Functions` instead of `// MARK: Extensions`.
+
+Xcode is also able to display `TODO` and `FIXME` tags directly in the source navigator, you should consider using them to find your notes inside your files.
+
+`// TODO: implement this feature`
+
+`// FIXME: fix it it's not working`
+
+Other conventional comment tags, such as `NOTE` and `XXX` are not recognized by Xcode.
 
 ### Statement Termination ###
 


### PR DESCRIPTION
Updated the file structure to add more details on enums and protocols to include the case where an enum / protocol is related to a class but has to be internal.

Updated the MARK section to remove the extra details and examples and leave more options to the developers on how to use them.
