### PR TITLE
Added ruleset for alphabetizing import statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 	* [Bracket Syntax](#bracket-syntax)
 	* [Force Unwrap](#force-unwrap)
 	* [Access Modifiers](#access-modifiers)
+	* [Imports](#imports)
 	* [Type Declarations](#type-declarations)
 	* [Type Inference](#type-inference)
 	* [Nil Checking](#nil-checking)
@@ -360,6 +361,25 @@ internal func doSomething() {
 
 // Wrong!
 weak public var obj: Object?
+
+### Imports ###
+
+Import statements should be at the very top of the code file, and they should be listed in alphabetical order.
+
+```swift
+import AFNetworking
+import Foundation
+import ReactiveCocoa
+import RealmSwift
+import UIKit
+```
+
+The exception is for imports that are for testing only; they should be placed at the bottom of the list, in alphabetical order:
+
+```swift
+import AFNetworking
+import UIKit
+@testable import MyLibrary
 ```
 
 ### Type Declarations ###


### PR DESCRIPTION
Proposal; rule that I used to abide by in C#. I think it has value here in organizing imports, as I don't think we have ever had any rulesets for imports in Objective-C. Thoughts? Alternatives? This seems pretty simple.
